### PR TITLE
fix: Fix hex parsing/stringifying in color utilities

### DIFF
--- a/src/ps/games/snakesladders/constants.ts
+++ b/src/ps/games/snakesladders/constants.ts
@@ -1,5 +1,5 @@
-import {StringToHex} from '@/utils/color';
+import { StringToHex } from '@/utils/color';
 
 export const TOKEN_COLORS = ['#ff0000', '#ff8000', '#ffff00', '#00ff00', '#00ffff', '#0000ff', '#9e00ff', '#ff00ff'].map(
-    color => StringToHex(color)!
+	color => StringToHex(color)!
 );

--- a/src/ps/games/snakesladders/constants.ts
+++ b/src/ps/games/snakesladders/constants.ts
@@ -1,3 +1,4 @@
 import type { Hex } from '@/utils/color';
+import {StringToHex} from '@/utils/color';
 
-export const TOKEN_COLORS = ['#ff0000', '#ff8000', '#ffff00', '#00ff00', '#00ffff', '#0000ff', '#9e00ff', '#ff00ff'] as Hex[];
+export const TOKEN_COLORS = ['#ff0000', '#ff8000', '#ffff00', '#00ff00', '#00ffff', '#0000ff', '#9e00ff', '#ff00ff'].map(color => StringToHex(color)!);

--- a/src/ps/games/snakesladders/constants.ts
+++ b/src/ps/games/snakesladders/constants.ts
@@ -1,4 +1,5 @@
-import type { Hex } from '@/utils/color';
 import {StringToHex} from '@/utils/color';
 
-export const TOKEN_COLORS = ['#ff0000', '#ff8000', '#ffff00', '#00ff00', '#00ffff', '#0000ff', '#9e00ff', '#ff00ff'].map(color => StringToHex(color)!);
+export const TOKEN_COLORS = ['#ff0000', '#ff8000', '#ffff00', '#00ff00', '#00ffff', '#0000ff', '#9e00ff', '#ff00ff'].map(
+    color => StringToHex(color)!
+);

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -104,9 +104,9 @@ export function normalizeHue(hue: number): number {
 // region Conversion Methods
 
 export function StringToHex(hex: string): Hex | null {
-	hex = hex.replace(/^#/, '');
-	if (![3, 4, 6, 8].includes(hex.length)) return null;
-	if (/^[0-9a-f]+$/i.test(hex)) return hex as Hex;
+	const hexVal = hex.replace(/^#/, '');
+	if (![3, 4, 6, 8].includes(hexVal.length)) return null;
+	if (/^[0-9a-f]+$/i.test(hexVal)) return hexVal as Hex;
 	return null;
 }
 

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -104,9 +104,9 @@ export function normalizeHue(hue: number): number {
 // region Conversion Methods
 
 export function StringToHex(hex: string): Hex | null {
-	const hexVal = hex.replace(/^#/, '');
-	if (![3, 4, 6, 8].includes(hexVal.length)) return null;
-	if (/^[0-9a-f]+$/i.test(hexVal)) return hex as Hex;
+	hex = hex.replace(/^#/, '');
+	if (![3, 4, 6, 8].includes(hex.length)) return null;
+	if (/^[0-9a-f]+$/i.test(hex)) return hex as Hex;
 	return null;
 }
 
@@ -125,7 +125,7 @@ export function HexToRgb(hex: Hex): Rgb {
 }
 
 export function RgbToHex({ R, G, B, a }: Rgb): Hex {
-	return `#${[R, G, B, ...(a! < 1 ? [Math.round(a! * 255)] : [])]
+	return `${[R, G, B, ...(a! < 1 ? [Math.round(a! * 255)] : [])]
 		.map(n => (Number.isNaN(n) ? 10 : Math.round(Math.min(Math.max(n, 0), 255))).toString(16).padStart(2, '0'))
 		.join('')}` as Hex;
 }


### PR DESCRIPTION
- Fixed StringToHex() and RgbToHex() to not include  '#" in the` output
- ConvertedTOKEN_COLORS to type Hex[] using StringToHex()